### PR TITLE
publish: Fix missing write packages permission

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -88,7 +88,7 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     needs: e2e-tests
-    if: ${{ github.ref_name == 'main' }}
+    if: ${{ github.repository == 'canonical/lxd-csi-driver' && github.ref_name == 'main' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Fixes missing write packages permission, and ensures Go version provided in go.mod is installed. Also limits image publishing to this repository