### PR TITLE
actions/k8s: Add action to setup K8s

### DIFF
--- a/.github/actions/setup-k8s/action.yml
+++ b/.github/actions/setup-k8s/action.yml
@@ -1,0 +1,34 @@
+name: Setup Kubernetes
+description: Setup Canonical Kubernetes cluster
+
+inputs:
+  k8s-cluster-name:
+    description: Name of the k8s cluster used as a prefix for various resources
+    default: "k8s"
+    type: string
+  k8s-node-count:
+    description: Number of nodes in the k8s cluster
+    default: 2
+    type: integer
+  k8s-snap-channel:
+    description: Snap channel to use for installing Canonical Kubernetes
+    default: "latest/edge"
+    type: string
+  k8s-kubeconfig-path:
+    description: Path where Kubeconfig file will be stored
+    default: "/home/runner/.kube/config"
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Deploy Kubernetes cluster
+      shell: bash
+      env:
+        K8S_CLUSTER_NAME: ${{ inputs.k8s-cluster-name }}
+        K8S_NODE_COUNT: ${{ inputs.k8s-node-count }}
+        K8S_SNAP_CHANNEL: ${{ inputs.k8s-snap-channel }}
+        K8S_KUBECONFIG_PATH: ${{ inputs.k8s-kubeconfig-path }}
+        K8S_CSI_IMAGE_PATH: lxd-csi-driver.tar
+      run: |
+        ${{ github.action_path }}/k8s.sh deploy

--- a/.github/actions/setup-k8s/k8s.sh
+++ b/.github/actions/setup-k8s/k8s.sh
@@ -12,7 +12,13 @@ source <(
   || { echo "Error: Failed to source bin/helpers from canonical/lxd-ci" >&2; exit 1; }
 )
 
+# Script dir where the script is located.
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Root dir of the repository.
+ROOT_DIR="$(realpath "${SCRIPT_DIR}/../../..")"
+
+# Temporary directory for job logs.
 JOB_DIR="$(mktemp -d -t lxd-csi-run.XXXXXX)"
 
 # Remove JOB dir on exit while preserving exit code.
@@ -52,7 +58,7 @@ setEnv() {
     # LXD Kubernetes cluster configuration.
     : "${K8S_NODE_COUNT:=1}"
     : "${K8S_SNAP_CHANNEL:=latest/edge}"
-    : "${K8S_KUBECONFIG_PATH:=${SCRIPT_DIR}/../.kube/${K8S_CLUSTER_NAME}.yml}" # Do not use "${HOME}/..." by default to avoid overwriting user's kubeconfig.
+    : "${K8S_KUBECONFIG_PATH:=${ROOT_DIR}/.kube/${K8S_CLUSTER_NAME}.yml}" # Do not use "${HOME}/..." by default to avoid overwriting user's kubeconfig.
     # K8S_CSI_IMAGE_PATH - Used to import locally built CSI image tarball to all cluster nodes.
 
     # LXD instance, storage, and network configuration.
@@ -379,7 +385,7 @@ k8sImportImageTarball() {
 # It creates the necessary namespace and applies the deployment manifests.
 installLXDCSIDriver() {
     local kubeconfigPath="${K8S_KUBECONFIG_PATH}"
-    local csiDeployPath="${SCRIPT_DIR}/../deploy"
+    local csiDeployPath="${ROOT_DIR}/deploy"
     local project="${LXD_PROJECT_NAME}"
     local name="${K8S_CLUSTER_NAME}-lxd-csi"
     local group="${name}-group"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -58,13 +58,12 @@ jobs:
           echo "K8S_KUBECONFIG_PATH=${HOME}/.kube/config" >> $GITHUB_ENV
 
       - name: Deploy Kubernetes cluster
-        env:
-          # Use locally built image from "Build CSI driver image" step.
-          K8S_CSI_IMAGE_PATH: lxd-csi-driver.tar
-          K8S_NODE_COUNT: "2"
-        run: |
-          set -e
-          ./scripts/k8s.sh deploy
+        uses: ./.github/actions/setup-k8s
+        with:
+          k8s-cluster-name: ${{ env.K8S_CLUSTER_NAME }}
+          k8s-node-count: 2
+          k8s-snap-channel: latest/edge
+          k8s-kubeconfig-path: ${{ env.K8S_KUBECONFIG_PATH }}
 
       - name: Print cluster info
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,13 +1,13 @@
 name: E2E Test
 on:
-  push:
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: e2e-tests-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 defaults:
@@ -82,40 +82,3 @@ jobs:
           cd test/e2e
           go install github.com/onsi/ginkgo/v2/ginkgo@v2.25.3
           ginkgo -v --timeout 30m .
-
-  # Publish container image to GHCR if tests passed and we are on main branch.
-  publish:
-    runs-on: ubuntu-24.04
-    needs: e2e-tests
-    if: ${{ github.repository == 'canonical/lxd-csi-driver' && github.ref_name == 'main' }}
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Install Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Build image
-        run: |
-          set -e
-          make build
-
-      - name: Log in to the container registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
-        with:
-          registry: ${{ env.CONTAINER_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
-          push: true
-          tags: ${{ env.CONTAINER_REGISTRY }}/${{ github.repository }}:latest-edge

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Publish CSI image
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+
+  e2e-tests:
+    needs: tests
+    uses: ./.github/workflows/e2e-tests.yml
+
+  # Publish container image to GHCR if tests passed and we are on main branch.
+  publish:
+    runs-on: ubuntu-24.04
+    needs: e2e-tests
+    if: ${{ github.repository == 'canonical/lxd-csi-driver' && github.ref_name == 'main' }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build image
+        run: |
+          set -e
+          make build
+
+      - name: Log in to the container registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ${{ env.CONTAINER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          push: true
+          tags: ${{ env.CONTAINER_REGISTRY }}/${{ github.repository }}:latest-edge

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,13 @@
 name: Tests
 on:
-  push:
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: tests-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 defaults:

--- a/scripts/k8s.sh
+++ b/scripts/k8s.sh
@@ -51,7 +51,7 @@ setEnv() {
 
     # LXD Kubernetes cluster configuration.
     : "${K8S_NODE_COUNT:=1}"
-    : "${K8S_SNAP_CHANNEL:=1.33-classic/stable}"
+    : "${K8S_SNAP_CHANNEL:=latest/edge}"
     : "${K8S_KUBECONFIG_PATH:=${SCRIPT_DIR}/../.kube/${K8S_CLUSTER_NAME}.yml}" # Do not use "${HOME}/..." by default to avoid overwriting user's kubeconfig.
     # K8S_CSI_IMAGE_PATH - Used to import locally built CSI image tarball to all cluster nodes.
 

--- a/scripts/k8s.sh
+++ b/scripts/k8s.sh
@@ -1,0 +1,1 @@
+../.github/actions/setup-k8s/k8s.sh


### PR DESCRIPTION
This PR:
- Uses helper functions from `bin/helpers` in `canonical/lxd`
- Move K8s script into `.github/actions` (Added symlink in scripts/k8s.sh for convenience)
- Use new action from e2e-test workflow
- Separates publish job into separate workflow which calls test workflows before publishin an image