### PR TITLE
deploy: Fix image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY=ghcr.io
-IMAGE=canonical/lxd-csi
+IMAGE=canonical/lxd-csi-driver
 # Use latest-edge for development builds to match what is in deploy/* manifests.
 VERSION=latest-edge
 

--- a/deploy/lxd-csi-controller.yaml
+++ b/deploy/lxd-csi-controller.yaml
@@ -97,7 +97,7 @@ spec:
                 - ALL
         # CSI controller.
         - name: lxd-csi-controller
-          image: ghcr.io/canonical/lxd-csi:latest-edge
+          image: ghcr.io/canonical/lxd-csi-driver:latest-edge
           imagePullPolicy: IfNotPresent
           args:
             - "--node-id=$(NODE_ID)"

--- a/deploy/lxd-csi-node.yaml
+++ b/deploy/lxd-csi-node.yaml
@@ -52,7 +52,7 @@ spec:
               drop:
                 - ALL
         - name: lxd-csi-node
-          image: ghcr.io/canonical/lxd-csi:latest-edge
+          image: ghcr.io/canonical/lxd-csi-driver:latest-edge
           imagePullPolicy: IfNotPresent
           args:
             - "--node-id=$(NODE_NAME)"


### PR DESCRIPTION
Fix image name from `lxd-csi` to `lxd-csi-driver` in deployment manifests to match the repository name.