### PR TITLE
publish: Fix missing env

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,7 +18,6 @@ defaults:
 
 env:
   K8S_CLUSTER_NAME: k8s
-  CONTAINER_REGISTRY: ghcr.io
 
 jobs:
   e2e-tests:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  CONTAINER_REGISTRY: ghcr.io
+
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml


### PR DESCRIPTION
Move env `CONTAINER_REGISTRY` from `e2e-tests` to `publish` workflow.