### PR TITLE
Print CSI logs and resource last state on test failure

### DIFF
--- a/test/e2e/e2e_debug.go
+++ b/test/e2e/e2e_debug.go
@@ -1,0 +1,141 @@
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+func printControllerLogs(ctx context.Context, client *kubernetes.Clientset, namespace string, name string, since time.Time) {
+	fmt.Printf("\n=== Controller logs ===\n")
+
+	dep, err := client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		fmt.Println("Failed to retrieve CSI controller Deployment:", err)
+		return
+	}
+
+	selector := labels.Set(dep.Spec.Selector.MatchLabels).AsSelector().String()
+	err = getPodLogsBySelector(ctx, client, namespace, selector, since)
+	if err != nil {
+		fmt.Println("Failed to retrieve CSI controller logs:", err)
+	}
+}
+
+func printNodeLogs(ctx context.Context, client *kubernetes.Clientset, namespace string, name string, since time.Time) {
+	fmt.Printf("\n===    Node logs    ===\n")
+
+	ds, err := client.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		fmt.Println("Failed to retrieve CSI node DaemonSet:", err)
+		return
+	}
+
+	selector := labels.Set(ds.Spec.Selector.MatchLabels).AsSelector().String()
+	err = getPodLogsBySelector(ctx, client, namespace, selector, since)
+	if err != nil {
+		fmt.Println("Failed to retrieve CSI node logs:", err)
+	}
+}
+
+// Print merged, chronological logs for all containers and all pods that match the provided selector.
+func getPodLogsBySelector(ctx context.Context, cs *kubernetes.Clientset, namespace string, selector string, since time.Time) error {
+	type logLine struct {
+		t   time.Time
+		msg string
+	}
+
+	pl, err := cs.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return err
+	}
+
+	if len(pl.Items) == 0 {
+		return fmt.Errorf("No pods found for selector %q", selector)
+	}
+
+	sinceTime := metav1.NewTime(since)
+	maxLines := int64(10) // Limit max number of lines per container to avoid flooding the output.
+
+	var lines []logLine
+	for _, p := range pl.Items {
+		// Discover all containers and sort by name.
+		containers := []string{}
+		for _, c := range p.Spec.Containers {
+			containers = append(containers, c.Name)
+		}
+
+		// Fetch logs for each container.
+		for _, c := range containers {
+			req := cs.CoreV1().Pods(namespace).GetLogs(p.Name, &corev1.PodLogOptions{
+				Container:  c,
+				SinceTime:  &sinceTime,
+				TailLines:  &maxLines,
+				Timestamps: true,
+			})
+
+			rc, err := req.Stream(ctx)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: Failed to stream log for %s/%s: %v\n", p.Name, c, err)
+				continue
+			}
+
+			// Parse the log lines.
+			func() {
+				defer rc.Close()
+
+				sc := bufio.NewScanner(rc)
+				for sc.Scan() {
+					raw := sc.Text()
+
+					// Split off the RFC3339Nano timestamp prefix.
+					i := strings.IndexByte(raw, ' ')
+					if i <= 0 {
+						continue
+					}
+
+					// Parse the timestamp to allow chronological sorting.
+					ts, err := time.Parse(time.RFC3339Nano, raw[:i])
+					if err != nil {
+						continue
+					}
+
+					// Store the timestamp and the line without timestamp.
+					lines = append(lines, logLine{
+						t:   ts,
+						msg: raw[i+1:],
+					})
+				}
+
+				_ = sc.Err()
+			}()
+		}
+
+		if len(lines) > 0 {
+			// Sort all lines chronologically.
+			// This helps understand the sequence of events when multiple containers are involved.
+			sort.Slice(lines, func(i, j int) bool {
+				return lines[i].t.Before(lines[j].t)
+			})
+
+			fmt.Printf("==> Logs for Pod %s\n", p.Name)
+			for _, l := range lines {
+				fmt.Println(l.msg)
+			}
+
+			// Reset for next pod.
+			lines = []logLine{}
+		}
+	}
+
+	return nil
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -41,6 +41,20 @@ func getTestLXDStoragePool() string {
 	return path
 }
 
+var _ = ginkgo.AfterEach(func() {
+	// Provide useful information when test fails.
+	rep := ginkgo.CurrentSpecReport()
+	if rep.Failed() {
+		// Ensure we do not hang waiting for logs.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		_, client := createClient()
+		printControllerLogs(ctx, client, "lxd-csi", "lxd-csi-controller", rep.StartTime)
+		printNodeLogs(ctx, client, "lxd-csi", "lxd-csi-node", rep.StartTime)
+	}
+})
+
 var _ = ginkgo.Describe("[Volume binding mode] ", func() {
 	var ctx context.Context
 	var client *kubernetes.Clientset

--- a/test/e2e/specs/pvc.go
+++ b/test/e2e/specs/pvc.go
@@ -3,6 +3,8 @@ package specs
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -13,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 )
 
 // PersistentVolumeClaim represents a Kubernetes PersistentVolumeClaim.
@@ -75,9 +78,52 @@ func (pvc PersistentVolumeClaim) WithSize(size string) PersistentVolumeClaim {
 	return pvc
 }
 
+// Events returns the events related to the PersistentVolumeClaim.
+func (pvc PersistentVolumeClaim) Events(ctx context.Context) (*corev1.EventList, error) {
+	return pvc.client.CoreV1().Events(pvc.Namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: "involvedObject.kind=PersistentVolumeClaim,involvedObject.name=" + pvc.Name,
+	})
+}
+
 // State returns the actual state of the PersistentVolumeClaim.
 func (pvc PersistentVolumeClaim) State(ctx context.Context) (*corev1.PersistentVolumeClaim, error) {
 	return pvc.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+}
+
+// StateString returns the state of the PersistentVolumeClaim as a string.
+// This is useful to include in error messages when desired state is not achieved.
+func (pvc PersistentVolumeClaim) StateString(ctx context.Context) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "PVC %q state:\n", pvc.PrettyName())
+
+	state, err := pvc.State(ctx)
+	if err != nil {
+		fmt.Fprintln(&b, "- Failed to get state:", err.Error())
+	} else {
+		fmt.Fprintln(&b, "- Phase:", state.Status.Phase)
+		fmt.Fprintln(&b, "- StorageClass:", ptr.Deref(pvc.Spec.StorageClassName, ""))
+		fmt.Fprintln(&b, "- VolumeName:", pvc.Spec.VolumeName)
+		fmt.Fprintf(&b, "- AccessModes: %v\n", state.Spec.AccessModes)
+
+		if len(state.Finalizers) > 0 {
+			fmt.Fprintf(&b, "- Finalizers: %v\n", state.Finalizers)
+		}
+
+		for _, c := range state.Status.Conditions {
+			fmt.Fprintf(&b, "- Condition %s=%s (%s: %s)\n", c.Type, c.Status, c.Reason, c.Message)
+		}
+	}
+
+	events, err := pvc.Events(ctx)
+	if err != nil {
+		fmt.Fprintln(&b, "- Failed to get events:", err.Error())
+	} else {
+		for _, e := range events.Items {
+			fmt.Fprintf(&b, "- Event %s %s: %s\n", e.Type, e.Reason, e.Message)
+		}
+	}
+
+	return b.String()
 }
 
 // Create creates the PersistentVolumeClaim in the Kubernetes cluster.
@@ -93,7 +139,7 @@ func (pvc PersistentVolumeClaim) Patch(ctx context.Context) {
 	bytes, err := json.Marshal(pvc.PersistentVolumeClaim)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to marshal PVC %q into JSON", pvc.PrettyName())
 	_, err = pvc.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Patch(ctx, pvc.Name, types.StrategicMergePatchType, bytes, metav1.PatchOptions{})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to patch PVC %q", pvc.PrettyName())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to patch PVC %q\n%s", pvc.PrettyName(), pvc.StateString(ctx))
 }
 
 // delete deletes the PersistentVolumeClaim from the Kubernetes cluster.
@@ -109,7 +155,7 @@ func (pvc PersistentVolumeClaim) delete(ctx context.Context, opts *metav1.Delete
 func (pvc PersistentVolumeClaim) Delete(ctx context.Context) {
 	ginkgo.By("Delete PersistentVolumeClaim " + pvc.PrettyName())
 	err := pvc.delete(ctx, nil)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to delete PVC %q", pvc.PrettyName())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to delete PVC %q\n%s", pvc.PrettyName(), pvc.StateString(ctx))
 }
 
 // ForceDelete forcefully deletes the PersistentVolumeClaim from the Kubernetes cluster.
@@ -135,7 +181,7 @@ func (pvc PersistentVolumeClaim) WaitBound(ctx context.Context, timeout time.Dur
 		return state.Status.Phase
 	}
 
-	gomega.Eventually(pvcPhase).WithTimeout(timeout).Should(gomega.Equal(corev1.ClaimBound), "PVC %q is not bound after %s", pvc.PrettyName(), timeout)
+	gomega.Eventually(pvcPhase).WithTimeout(timeout).Should(gomega.Equal(corev1.ClaimBound), "PVC %q is not bound after %s\n%s", pvc.PrettyName(), timeout, pvc.StateString(ctx))
 }
 
 // WaitSize waits until the PersistentVolumeClaim is resized to desired size.
@@ -155,7 +201,7 @@ func (pvc PersistentVolumeClaim) WaitSize(ctx context.Context, size string, time
 		return v.String()
 	}
 
-	gomega.Eventually(pvcSize).WithTimeout(timeout).Should(gomega.Equal(size), "PVC %q size is not %q after %s", pvc.PrettyName(), size, timeout)
+	gomega.Eventually(pvcSize).WithTimeout(timeout).Should(gomega.Equal(size), "PVC %q size is not %q after %s\n%s", pvc.PrettyName(), size, timeout, pvc.StateString(ctx))
 }
 
 // WaitGone waits until the PVC is no longer present in the Kubernetes cluster.
@@ -166,5 +212,5 @@ func (pvc PersistentVolumeClaim) WaitGone(ctx context.Context, timeout time.Dura
 		return apierrors.IsNotFound(err)
 	}
 
-	gomega.Eventually(podGone).WithTimeout(timeout).Should(gomega.BeTrue(), "PVC %q is not gone after %s", pvc.PrettyName(), timeout)
+	gomega.Eventually(podGone).WithTimeout(timeout).Should(gomega.BeTrue(), "PVC %q is not gone after %s\n%s", pvc.PrettyName(), timeout, pvc.StateString(ctx))
 }

--- a/test/e2e/specs/storageclass.go
+++ b/test/e2e/specs/storageclass.go
@@ -2,7 +2,9 @@ package specs
 
 import (
 	"context"
+	"fmt"
 	"maps"
+	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -10,6 +12,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 
 	"github.com/canonical/lxd-csi-driver/internal/driver"
 )
@@ -89,11 +92,41 @@ func (sc StorageClass) State(ctx context.Context) (*storagev1.StorageClass, erro
 	return sc.client.StorageV1().StorageClasses().Get(ctx, sc.Name, metav1.GetOptions{})
 }
 
+// StateString returns the state of the StorageClass as a string.
+// This is useful to include in error messages when desired state is not achieved.
+func (sc StorageClass) StateString(ctx context.Context) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "StorageClass %q state:\n", sc.PrettyName())
+
+	state, err := sc.State(ctx)
+	if err != nil {
+		fmt.Fprintln(&b, "- Failed to get state:", err.Error())
+	} else {
+		fmt.Fprintln(&b, "- Provisioner:", state.Provisioner)
+		fmt.Fprintln(&b, "- ReclaimPolicy:", ptr.Deref(sc.ReclaimPolicy, ""))
+		fmt.Fprintln(&b, "- VolumeBindingMode:", ptr.Deref(sc.VolumeBindingMode, ""))
+
+		if len(sc.AllowedTopologies) > 0 {
+			fmt.Fprintf(&b, "- AllowedTopologies: %v\n", sc.AllowedTopologies)
+		}
+
+		if len(sc.MountOptions) > 0 {
+			fmt.Fprintf(&b, "- MountOptions: %v\n", sc.MountOptions)
+		}
+
+		if len(sc.Parameters) > 0 {
+			fmt.Fprintf(&b, "- Parameters: %v\n", sc.Parameters)
+		}
+	}
+
+	return b.String()
+}
+
 // Create creates the StorageClass in the Kubernetes cluster.
 func (sc StorageClass) Create(ctx context.Context) {
 	ginkgo.By("Create StorageClass " + sc.PrettyName())
 	_, err := sc.client.StorageV1().StorageClasses().Create(ctx, &sc.StorageClass, metav1.CreateOptions{})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create StorageClass %q", sc.PrettyName())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create StorageClass %q", sc.PrettyName(), sc.StateString(ctx))
 }
 
 // delete deletes the StorageClass from the Kubernetes cluster.
@@ -109,7 +142,7 @@ func (sc StorageClass) delete(ctx context.Context, opts *metav1.DeleteOptions) e
 func (sc StorageClass) Delete(ctx context.Context) {
 	ginkgo.By("Delete StorageClass " + sc.PrettyName())
 	err := sc.delete(ctx, nil)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to delete StorageClass %q", sc.PrettyName())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to delete StorageClass %q", sc.PrettyName(), sc.StateString(ctx))
 }
 
 // ForceDelete forcefully deletes the StorageClass from the Kubernetes cluster.


### PR DESCRIPTION
Prints error messages like this:
```
=== Controller logs ===
==> Logs for Pod lxd-csi-controller-7b6cc86c4d-nqnw5
I0926 15:31:05.077053       1 event.go:389] "Event occurred" object="default/pvc-20250926-153049-00zyr" fieldPath="" kind="PersistentVolumeClaim" apiVersion="v1" type="Warning" reason="ProvisioningFailed" message=<
        failed to provision volume with StorageClass "sc-20250926-153049-clvkz": rpc error: code = Internal desc = CreateVolume: Failed to retrieve storage pool "invalid-sc": Storage pool not found
 >
I0926 15:31:20.062378       1 event.go:389] "Event occurred" object="default/pvc-20250926-153049-00zyr" fieldPath="" kind="PersistentVolumeClaim" apiVersion="v1" type="Normal" reason="Provisioning" message="External provisioner is provisioning volume for claim \"default/pvc-20250926-153049-00zyr\""
I0926 15:31:20.084119       1 controller.go:1094] "Final error received, removing PVC from claims in progress" claimUID="5cd4856f-6adb-4469-b1d3-9b9b4902f821"
I0926 15:31:20.084145       1 controller.go:951] "Retrying syncing claim" key="5cd4856f-6adb-4469-b1d3-9b9b4902f821" failures=5
E0926 15:31:20.084165       1 controller.go:974] error syncing claim "5cd4856f-6adb-4469-b1d3-9b9b4902f821": failed to provision volume with StorageClass "sc-20250926-153049-clvkz": rpc error: code = Internal desc = CreateVolume: Failed to retrieve storage pool "invalid-sc": Storage pool not found
I0926 15:31:20.084189       1 event.go:389] "Event occurred" object="default/pvc-20250926-153049-00zyr" fieldPath="" kind="PersistentVolumeClaim" apiVersion="v1" type="Warning" reason="ProvisioningFailed" message=<
        failed to provision volume with StorageClass "sc-20250926-153049-clvkz": rpc error: code = Internal desc = CreateVolume: Failed to retrieve storage pool "invalid-sc": Storage pool not found
>

===    Node logs    ===
...
```

Controller and node logs are included for every failed test. 
It prints only logs generated during the test, and I've put a limit of 10 lines per container to prevent bloating logs (usually the error is in the last line, but if necessary, we will increase it later).

Additionally, it will print the last state of the failed resource (pod, pvc, storageclass).
Example:
```
------------------------------
• [FAILED] [30.381 seconds]
[Volume binding mode]  [It] Test failure

  [FAILED] Timed out after 30.001s.
  PVC "default/pvc-20250926-153049-00zyr" is not bound after 30s
  PVC "default/pvc-20250926-153049-00zyr" state:
  - Phase: Pending
  - StorageClass: sc-20250926-153049-clvkz
  - VolumeName: 
  - AccessModes: [ReadWriteOnce]
  - Finalizers: [kubernetes.io/pvc-protection]
```