### PR TITLE
deploy/lxd-csi-driverinfo: Set FS group policy to File

### DIFF
--- a/deploy/lxd-csi-driverinfo.yaml
+++ b/deploy/lxd-csi-driverinfo.yaml
@@ -4,6 +4,7 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: lxd.csi.canonical.com
 spec:
+  fsGroupPolicy: File
   attachRequired: true
   volumeLifecycleModes:
     - Persistent


### PR DESCRIPTION
The default value for FS group policy is `ReadWriteOnceWithFSType`, which lets Kubelet adjust FS ownership only if FS type is set in storage class parameters as `csi.storage.k8s.io/fstype`. The FS group policy `File` lets Kubelet examine the FS and adjust ownership based on Pod's security context even if FS type is not set in the storage class.