### PR TITLE
deploy: Change secret name

### DIFF
--- a/.github/actions/setup-k8s/k8s.sh
+++ b/.github/actions/setup-k8s/k8s.sh
@@ -409,7 +409,7 @@ installLXDCSIDriver() {
 
     echo "===> Installing LXD CSI driver ..."
     kubectl --kubeconfig "${kubeconfigPath}" create namespace lxd-csi --save-config
-    kubectl --kubeconfig "${kubeconfigPath}" create secret generic lxd-csi-token --namespace lxd-csi --from-literal=token="${token}"
+    kubectl --kubeconfig "${kubeconfigPath}" create secret generic lxd-csi-secret --namespace lxd-csi --from-literal=token="${token}"
     kubectl --kubeconfig "${kubeconfigPath}" apply -f "${csiDeployPath}"
 }
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Create a namespace `lxd-csi`:
 kubectl create namespace lxd-csi --save-config
 ```
 
-Create a Kubernetes secret `lxd-csi-token` containing a previously created bearer token:
+Create a Kubernetes secret `lxd-csi-secret` containing a previously created bearer token:
 ```sh
-kubectl create secret generic lxd-csi-token \
+kubectl create secret generic lxd-csi-secret \
     --namespace lxd-csi \
     --from-literal=token="${token}"
 ```

--- a/charts/README.md
+++ b/charts/README.md
@@ -10,7 +10,7 @@ By default, the chart expects the Secret to be named `lxd-csi-secret`, but this 
 apiVersion: v1
 kind: Secret
 metadata:
-  name: lxd-csi-token
+  name: lxd-csi-secret
   namespace: lxd-csi # Secret must be in the same namespace as LXD CSI driver.
 type: Opaque
 stringData:

--- a/deploy/lxd-csi-controller.yaml
+++ b/deploy/lxd-csi-controller.yaml
@@ -117,7 +117,7 @@ spec:
               mountPath: /csi
             - name: devlxd-socket
               mountPath: /dev/lxd/sock
-            - name: lxd-csi-token
+            - name: lxd-csi-secret
               mountPath: /etc/lxd-csi-driver
               readOnly: true
           resources:
@@ -131,9 +131,9 @@ spec:
               drop:
                 - ALL
       volumes:
-        - name: lxd-csi-token
+        - name: lxd-csi-secret
           secret:
-            secretName: lxd-csi-token
+            secretName: lxd-csi-secret
         - name: devlxd-socket
           hostPath:
             path: /dev/lxd/sock

--- a/deploy/lxd-csi-node.yaml
+++ b/deploy/lxd-csi-node.yaml
@@ -78,7 +78,7 @@ spec:
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet
               mountPropagation: Bidirectional
-            - name: lxd-csi-token
+            - name: lxd-csi-secret
               mountPath: /etc/lxd-csi-driver
               readOnly: true
           resources:
@@ -105,9 +105,9 @@ spec:
           hostPath:
             path: /var/lib/kubelet
             type: Directory
-        - name: lxd-csi-token
+        - name: lxd-csi-secret
           secret:
-            secretName: lxd-csi-token
+            secretName: lxd-csi-secret
         - name: lxd-mount-dir
           hostPath:
             # CSI requests from LXD to mount filesystem volumes in this directory.


### PR DESCRIPTION
Change secret name from `lxd-csi-token` to `lxd-csi-secret` to make it consistent with Helm chart and across docs.