### PR TITLE
feat: add raw block volume and custom mount options support for VMs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
-FROM scratch
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    e2fsprogs \
+    xfsprogs \
+    btrfs-progs \
+    util-linux \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY lxd-csi /bin/lxd-csi
 ENTRYPOINT ["/bin/lxd-csi"]

--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -97,9 +97,36 @@ func (c *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		switch k {
 		case ParameterStoragePool:
 			parameters[k] = v
+		case ParameterBlockFilesystem:
+			parameters[k] = v
+		case ParameterBlockMountOptions:
+			parameters[k] = v
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "CreateVolume: Invalid parameter %q in storage class", k)
 		}
+	}
+
+	fsType := parameters[ParameterBlockFilesystem]
+	if fsType == "" {
+		for _, c := range req.VolumeCapabilities {
+			if mnt := c.GetMount(); mnt != nil {
+				fsType = mnt.GetFsType()
+				if fsType != "" {
+					break
+				}
+			}
+		}
+	}
+
+	volumeConfig := map[string]string{
+		"size": strconv.FormatInt(sizeBytes, 10),
+	}
+
+	if fsType != "" {
+		contentType = "block"
+		// Do not pass block.filesystem or block.mount_options to LXD in volumeConfig,
+		// because raw block volumes do not support these filesystem configuration options on LXD side.
+		// Our NodePublishVolume will handle formatting and mounting inside the node.
 	}
 
 	poolName := req.Parameters[ParameterStoragePool]
@@ -323,9 +350,7 @@ func (c *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 			},
 			DevLXDStorageVolumePut: api.DevLXDStorageVolumePut{
 				Description: volumeDescription,
-				Config: map[string]string{
-					"size": strconv.FormatInt(sizeBytes, 10),
-				},
+				Config:      volumeConfig,
 			},
 		}
 
@@ -345,9 +370,7 @@ func (c *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 			ContentType: contentType,
 			DevLXDStorageVolumePut: api.DevLXDStorageVolumePut{
 				Description: volumeDescription,
-				Config: map[string]string{
-					"size": strconv.FormatInt(sizeBytes, 10),
-				},
+				Config:      volumeConfig,
 			},
 		}
 
@@ -557,7 +580,7 @@ func (c *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 	defer unlock()
 
 	// Get existing storage pool volume.
-	_, _, err = client.GetStoragePoolVolume(poolName, "custom", volName)
+	vol, _, err := client.GetStoragePoolVolume(poolName, "custom", volName)
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			return nil, status.Errorf(codes.NotFound, "ControllerPublishVolume: Volume %q not found in storage pool %q", volName, poolName)
@@ -593,7 +616,12 @@ func (c *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 
 	if contentType == "filesystem" {
 		// For filesystem volumes, provide the path where the volume is mounted.
-		reqInst.Devices[volName]["path"] = filepath.Join(driverFileSystemMountPath, volName)
+		// If the volume has ContentType "block" and is being attached to a virtual machine,
+		// we must not specify "path" so that LXD attaches it as a raw block device instead of via virtiofs.
+		isBlockVolume := vol.ContentType == "block"
+		if !isBlockVolume || !c.driver.IsVirtualMachine() {
+			reqInst.Devices[volName]["path"] = filepath.Join(driverFileSystemMountPath, volName)
+		}
 	}
 
 	err = client.UpdateInstance(req.NodeId, reqInst, etag)

--- a/internal/driver/controller_test.go
+++ b/internal/driver/controller_test.go
@@ -27,6 +27,9 @@ type fakeDevLXDServer struct {
 
 	getVolFunc    func(pool string, volType string, name string) (*api.DevLXDStorageVolume, string, error)
 	updateVolFunc func(pool string, volType string, name string, volume api.DevLXDStorageVolumePut, ETag string) (lxdClient.DevLXDOperation, error)
+	getPoolFunc   func(name string) (*api.DevLXDStoragePool, string, error)
+	getStateFunc  func() (*api.DevLXDGet, error)
+	createVolFunc func(pool string, volume api.DevLXDStorageVolumesPost) (lxdClient.DevLXDOperation, error)
 }
 
 func (f *fakeDevLXDServer) GetStoragePoolVolume(pool string, volType string, name string) (*api.DevLXDStorageVolume, string, error) {
@@ -39,6 +42,27 @@ func (f *fakeDevLXDServer) GetStoragePoolVolume(pool string, volType string, nam
 func (f *fakeDevLXDServer) UpdateStoragePoolVolume(pool string, volType string, name string, volume api.DevLXDStorageVolumePut, ETag string) (lxdClient.DevLXDOperation, error) {
 	if f.updateVolFunc != nil {
 		return f.updateVolFunc(pool, volType, name, volume, ETag)
+	}
+	return &fakeDevLXDOperation{}, nil
+}
+
+func (f *fakeDevLXDServer) GetStoragePool(name string) (*api.DevLXDStoragePool, string, error) {
+	if f.getPoolFunc != nil {
+		return f.getPoolFunc(name)
+	}
+	return nil, "", nil
+}
+
+func (f *fakeDevLXDServer) GetState() (*api.DevLXDGet, error) {
+	if f.getStateFunc != nil {
+		return f.getStateFunc()
+	}
+	return nil, nil
+}
+
+func (f *fakeDevLXDServer) CreateStoragePoolVolume(pool string, volume api.DevLXDStorageVolumesPost) (lxdClient.DevLXDOperation, error) {
+	if f.createVolFunc != nil {
+		return f.createVolFunc(pool, volume)
 	}
 	return &fakeDevLXDOperation{}, nil
 }
@@ -119,4 +143,108 @@ func TestControllerExpandVolumePreservesConfig(t *testing.T) {
 
 	require.True(t, calledGet, "GetStoragePoolVolume should have been called")
 	require.True(t, calledUpdate, "UpdateStoragePoolVolume should have been called")
+}
+
+func TestCreateVolumeWithBlockFilesystem(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expectedFs string
+	}{
+		{
+			name: "Explicit block.filesystem",
+			parameters: map[string]string{
+				"storagePool":         "remote",
+				"block.filesystem":    "xfs",
+				"block.mount_options": "noatime",
+			},
+			expectedFs: "xfs",
+		},
+		{
+			name: "Standard fallback fstype",
+			parameters: map[string]string{
+				"storagePool":               "remote",
+				"csi.storage.k8s.io/fstype": "ext4",
+			},
+			expectedFs: "ext4",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Initialize driver and controller server
+			d := &Driver{
+				name:     "lxd.csi.canonical.com",
+				version:  "test",
+				endpoint: "unix:///csi/csi.sock",
+				nodeID:   "test-node",
+			}
+
+			var calledCreate bool
+			fakeClient := &fakeDevLXDServer{
+				getPoolFunc: func(name string) (*api.DevLXDStoragePool, string, error) {
+					return &api.DevLXDStoragePool{
+						Name:   "remote",
+						Driver: "dir",
+					}, "test-pool-etag", nil
+				},
+				getStateFunc: func() (*api.DevLXDGet, error) {
+					return &api.DevLXDGet{
+						DevLXDGetUntrusted: api.DevLXDGetUntrusted{
+							Auth: api.AuthTrusted,
+							SupportedStorageDrivers: []api.DevLXDServerStorageDriverInfo{
+								{Name: "dir", Remote: false},
+							},
+						},
+					}, nil
+				},
+				getVolFunc: func(pool string, volType string, name string) (*api.DevLXDStorageVolume, string, error) {
+					// Return not found for volume check during creation
+					return nil, "", api.NewStatusError(404, "Not Found")
+				},
+				createVolFunc: func(pool string, volume api.DevLXDStorageVolumesPost) (lxdClient.DevLXDOperation, error) {
+					calledCreate = true
+					require.Equal(t, "remote", pool)
+					require.Equal(t, "custom", volume.Type)
+					require.Equal(t, "block", volume.ContentType)
+					require.NotContains(t, volume.Config, "block.filesystem")
+					require.NotContains(t, volume.Config, "block.mount_options")
+					require.Equal(t, "10737418240", volume.Config["size"]) // 10Gi
+					return &fakeDevLXDOperation{}, nil
+				},
+			}
+
+			d.devLXD = fakeClient
+			controller := NewControllerServer(d)
+
+			req := &csi.CreateVolumeRequest{
+				Name: "pvc-test-volume",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 10737418240, // 10Gi
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{
+								FsType: tc.expectedFs,
+							},
+						},
+					},
+				},
+				Parameters: tc.parameters,
+			}
+
+			resp, err := controller.CreateVolume(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotNil(t, resp.Volume)
+			require.Contains(t, resp.Volume.VolumeId, "remote/pvc-")
+			require.Equal(t, int64(10737418240), resp.Volume.CapacityBytes)
+			require.Equal(t, "dir", resp.Volume.VolumeContext[ParameterStorageDriver])
+			require.True(t, calledCreate, "CreateStoragePoolVolume should have been called")
+		})
+	}
 }

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -68,6 +68,14 @@ const (
 	// This is internal parameter used only by the CSI driver.
 	ParameterStorageDriver = "internal.storageDriver"
 
+	// ParameterBlockFilesystem is the name of the storage class parameter
+	// that specifies the filesystem type for block-backed volumes.
+	ParameterBlockFilesystem = "block.filesystem"
+
+	// ParameterBlockMountOptions is the name of the storage class parameter
+	// that specifies the mount options for block-backed volumes.
+	ParameterBlockMountOptions = "block.mount_options"
+
 	// ParameterPVCName contains the name of the PVC that triggered volume creation.
 	// It is passed to the controller by the CSI provisioner.
 	ParameterPVCName = "csi.storage.k8s.io/pvc/name"
@@ -126,8 +134,9 @@ type Driver struct {
 	hasDevLXDTokenChanged bool
 
 	// LXD cluster member where instance is running on.
-	location    string
-	isClustered bool
+	location     string
+	isClustered  bool
+	instanceType string
 
 	// Prefix used for LXD volume names.
 	volumeNamePrefix string
@@ -225,9 +234,17 @@ func (d *Driver) DevLXDClient() (lxdClient.DevLXDServer, error) {
 	d.devLXD = devLXDClient
 	d.location = info.Location
 	d.isClustered = info.Environment.ServerClustered
+	d.instanceType = info.InstanceType
 	d.hasDevLXDTokenChanged = false
 
 	return d.devLXD, nil
+}
+
+// IsVirtualMachine returns true if the driver is running inside a virtual machine.
+func (d *Driver) IsVirtualMachine() bool {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	return d.instanceType == "virtual-machine"
 }
 
 // Run starts CSI driver gRPC server.

--- a/internal/driver/node.go
+++ b/internal/driver/node.go
@@ -97,7 +97,44 @@ func (n *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 			return nil, status.Errorf(codes.Internal, "NodePublishVolume: Source device for volume %q not found: %v", volName, err)
 		}
 	case *csi.VolumeCapability_Mount:
-		// Construct the source path for the filesystem volume.
+		// Check if the volume is attached as a block device to the node (applicable inside VMs).
+		blockDevicePath, err := getDiskDevicePath(volName)
+		if err == nil && blockDevicePath != "" {
+			// Read mount flags and fsType from the request.
+			mnt := req.VolumeCapability.GetMount()
+			var blockMountOptions []string
+			if req.Readonly {
+				blockMountOptions = append(blockMountOptions, "ro")
+			}
+			blockMountOptions = append(blockMountOptions, mnt.MountFlags...)
+
+			// Read and apply custom mount options specified in StorageClass via VolumeContext
+			if customOpts := req.VolumeContext[ParameterBlockMountOptions]; customOpts != "" {
+				for _, opt := range strings.Split(customOpts, ",") {
+					opt = strings.TrimSpace(opt)
+					if opt != "" {
+						blockMountOptions = append(blockMountOptions, opt)
+					}
+				}
+			}
+
+			fsType := mnt.GetFsType()
+			if fsType == "" {
+				fsType = req.VolumeContext[ParameterBlockFilesystem]
+			}
+			if fsType == "" {
+				fsType = "ext4" // default fallback
+			}
+
+			// Format (if needed) and mount the block device.
+			err = fs.FormatAndMount(blockDevicePath, targetPath, fsType, blockMountOptions)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "NodePublishVolume: Failed to format and mount block device %q: %v", blockDevicePath, err)
+			}
+			return &csi.NodePublishVolumeResponse{}, nil
+		}
+
+		// Fallback for directory shares (applicable inside Containers or standard filesystem custom volumes on VMs via virtiofs).
 		sourcePath = filepath.Join(driverFileSystemMountPath, volName)
 
 		// Read mount flags from the request.

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 	"k8s.io/klog/v2"
 	kmount "k8s.io/mount-utils"
+	utilexec "k8s.io/utils/exec"
 
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 )
@@ -254,6 +255,34 @@ func WatchFile(ctx context.Context, path string, fileChangeHandler func(path str
 			}
 		}
 	}()
+
+	return nil
+}
+
+// FormatAndMount formats a block device with the specified filesystem (if not already formatted) and mounts it.
+func FormatAndMount(sourcePath string, targetPath string, fsType string, mountOptions []string) error {
+	if sourcePath == "" {
+		return errors.New("Volume mount source path is not specified")
+	}
+
+	if targetPath == "" {
+		return errors.New("Volume mount target path is not specified")
+	}
+
+	err := os.MkdirAll(targetPath, 0750)
+	if err != nil {
+		return err
+	}
+
+	mounter := &kmount.SafeFormatAndMount{
+		Interface: kmount.New(""),
+		Exec:      utilexec.New(),
+	}
+
+	err = mounter.FormatAndMount(sourcePath, targetPath, fsType, mountOptions)
+	if err != nil {
+		return fmt.Errorf("FormatAndMount failed: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION

  Support native raw block filesystems (ext4/xfs) on LXD VMs

  Description
  This Pull Request introduces the ability to provision, format, and safely mount LXD custom storage volumes as native raw block devices inside Virtual Machines (VMs).

  The Rationale
  Currently, when a VM requests a volume in Filesystem mode, the CSI driver always attaches the volume by specifying the "path" parameter. This forces LXD to share the volume using the virtiofs (or 9p) protocol, effectively ignoring any filesystem (e.g., ext4, xfs) specified in the StorageClass.

  While virtiofs provides great flexibility for ReadWriteMany (shared directory) scenarios, it introduces non-negligible CPU overhead and significant performance degradation during heavy I/O operations involving many small files (e.g., databases, code compilation).

  With this solution, we give cluster administrators and users the freedom to choose:
   * Shared directory volumes (virtiofs): For shared-use cases and seamless online expansion.
   * Native raw block volumes (ext4/xfs on disk): To maximize IOPS and minimize latency, by attaching volumes as virtual SCSI
     block devices (e.g., /dev/sdb).

  ---

  What has been implemented

   1. Filesystem Detection during Provisioning (CreateVolume):
      The driver now reads the block.filesystem StorageClass parameter or, as a fallback, extracts the standard filesystem type (e.g., csi.storage.k8s.io/fstype) from the request's VolumeCapabilities. If present, it sets the LXD volume's content type to "block".
   2. Clean LXD Storage Volume Configuration:
      We excluded passing block.filesystem and block.mount_options directly to the LXD API during volume creation, as raw block volumes do not support these filesystem configuration properties on the host side (preventing Invalid option errors).
   3. Raw Block Attachment on VMs (ControllerPublishVolume):
      If the volume's content type is "block" and the target node is a Virtual Machine, the controller omits the "path" key in LXD's device configuration, attaching the volume as a raw block SCSI device.
   4. Safe Formatting and Mounting inside the Guest (NodePublishVolume):
      The node driver detects the block device (e.g., /dev/sdb), excludes the "bind" option (invalid for raw blocks), and utilizes Kubernetes' official SafeFormatAndMount utility to safely format the device (only if unformatted, preventing data loss) and mount the filesystem inside the guest.
   5. Support for Custom Mount Options:
      Added support for parsing block.mount_options (e.g., noatime,nodiratime,discard) from the StorageClass to optimize kernel I/O operations and enable hardware TRIM/unmap (discard) on Ceph/LVM backends.
   6. Upgraded Base Image to Ubuntu 24.04 LTS (Dockerfile):
      We migrated the Dockerfile base image from a bare FROM scratch to the official Ubuntu 24.04 LTS (Noble Numbat) to package essential system utilities (blkid from util-linux, e2fsprogs, xfsprogs, and btrfs-progs) required for node-side formatting, forcing the compilation targeting the linux/amd64 platform.
       * Note for reviewers: I chose Ubuntu 24.04 LTS as it is Canonical's official and
         standard base, but please let me know if a more minimal alternative (such as Ubuntu
         Chiseled or a different lightweight base) is preferred for this project.
   7. Table-Driven Unit Testing:
      Implemented a comprehensive, mocked, table-driven unit test suite to validate provisioning flows against different StorageClass configurations.

  ---

  Caveats & Trade-offs (Offline Expansion)
  On block-backed storage pools (such as Ceph or LVM), LXD does not support "on-the-fly" (online) expansion of custom volumes
  while they are actively attached to a running instance.

  Therefore, resizing the volume requires Offline Expansion:
   1. Temporarily scale down or delete the Pod using the PVC (which detaches the volume).
   2. The driver successfully resizes the storage volume offline on the LXD side.
   3. Recreate/scale up the Pod, which re-attaches the volume with the new capacity and triggers automatic filesystem
      expansion.

  We believe this is a highly acceptable trade-off given the bare-metal-like performance achieved through direct block device access.

  ---

  Usage Example

```
    1 apiVersion: storage.k8s.io/v1
    2 kind: StorageClass
    3 metadata:
    4   name: lxd-block-ext4
    5 provisioner: lxd.csi.canonical.com
    6 allowVolumeExpansion: true
    7 volumeBindingMode: WaitForFirstConsumer
    8 parameters:
    9   storagePool: remote
   10   csi.storage.k8s.io/fstype: ext4
   11   block.mount_options: noatime,nodiratime,discard
```

  ---
