### PR TITLE
Report node volume stats

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -298,7 +298,10 @@ func (d *Driver) Run() error {
 
 		csi.RegisterControllerServer(d.server, NewControllerServer(d))
 	} else {
-		d.SetNodeServiceCapabilities()
+		d.SetNodeServiceCapabilities(
+			csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+		)
+
 		csi.RegisterNodeServer(d.server, NewNodeServer(d))
 	}
 

--- a/internal/driver/node.go
+++ b/internal/driver/node.go
@@ -12,6 +12,8 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/canonical/lxd-csi-driver/internal/fs"
+	"github.com/canonical/lxd/lxd/storage/block"
+	"github.com/canonical/lxd/shared"
 )
 
 type nodeServer struct {
@@ -42,6 +44,70 @@ func (n *nodeServer) NodeGetInfo(_ context.Context, _ *csi.NodeGetInfoRequest) (
 		AccessibleTopology: &csi.Topology{
 			Segments: map[string]string{
 				AnnotationLXDClusterMember: n.driver.location,
+			},
+		},
+	}, nil
+}
+
+// NodeGetVolumeStats returns the capacity and inode usage of the volume on this node.
+func (n *nodeServer) NodeGetVolumeStats(_ context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	_, _, _, err := splitVolumeID(req.VolumeId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "NodeGetVolumeStats: %v", err)
+	}
+
+	volumePath := req.VolumePath
+	if volumePath == "" {
+		return nil, status.Error(codes.InvalidArgument, "NodeGetVolumeStats: Volume path not provided")
+	}
+
+	// The volume path must be an active mount point. Otherwise, the reported statistics
+	// would belong to the filesystem that hosts the volume path, and not to the volume.
+	mounted, err := fs.IsMountPoint(volumePath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "NodeGetVolumeStats: %v", err)
+	}
+
+	if !mounted {
+		return nil, status.Errorf(codes.NotFound, "NodeGetVolumeStats: Volume path %q is not mounted", volumePath)
+	}
+
+	// Raw block volumes are not formatted by the driver, therefore only the total
+	// size of the block device can be reported.
+	if shared.IsBlockdevPath(volumePath) {
+		size, err := block.DiskSizeBytes(volumePath)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "NodeGetVolumeStats: %v", err)
+		}
+
+		return &csi.NodeGetVolumeStatsResponse{
+			Usage: []*csi.VolumeUsage{
+				{
+					Unit:  csi.VolumeUsage_BYTES,
+					Total: size,
+				},
+			},
+		}, nil
+	}
+
+	stats, err := fs.Usage(volumePath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "NodeGetVolumeStats: %v", err)
+	}
+
+	return &csi.NodeGetVolumeStatsResponse{
+		Usage: []*csi.VolumeUsage{
+			{
+				Unit:      csi.VolumeUsage_BYTES,
+				Total:     stats.TotalBytes,
+				Used:      stats.UsedBytes,
+				Available: stats.AvailableBytes,
+			},
+			{
+				Unit:      csi.VolumeUsage_INODES,
+				Total:     stats.TotalInodes,
+				Used:      stats.UsedInodes,
+				Available: stats.FreeInodes,
 			},
 		},
 	}, nil

--- a/internal/driver/node_test.go
+++ b/internal/driver/node_test.go
@@ -1,0 +1,83 @@
+package driver
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNodeGetVolumeStatsInvalidRequest(t *testing.T) {
+	node := NewNodeServer(&Driver{})
+	dir := t.TempDir()
+
+	tests := []struct {
+		name         string
+		req          *csi.NodeGetVolumeStatsRequest
+		expectedCode codes.Code
+	}{
+		{
+			name:         "Empty volume ID",
+			req:          &csi.NodeGetVolumeStatsRequest{VolumePath: dir},
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name:         "Malformed volume ID",
+			req:          &csi.NodeGetVolumeStatsRequest{VolumeId: "pvc-volume-name", VolumePath: dir},
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name:         "Empty volume path",
+			req:          &csi.NodeGetVolumeStatsRequest{VolumeId: "remote/pvc-volume-name"},
+			expectedCode: codes.InvalidArgument,
+		},
+		{
+			name:         "Non-existing volume path",
+			req:          &csi.NodeGetVolumeStatsRequest{VolumeId: "remote/pvc-volume-name", VolumePath: filepath.Join(dir, "non-existing")},
+			expectedCode: codes.NotFound,
+		},
+		{
+			name:         "Volume path is not a mount point",
+			req:          &csi.NodeGetVolumeStatsRequest{VolumeId: "remote/pvc-volume-name", VolumePath: dir},
+			expectedCode: codes.NotFound,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resp, err := node.NodeGetVolumeStats(t.Context(), test.req)
+			require.Nil(t, resp)
+			require.Equal(t, test.expectedCode, status.Code(err))
+		})
+	}
+}
+
+// Filesystem volumes report both the capacity and the inode usage.
+func TestNodeGetVolumeStatsFilesystem(t *testing.T) {
+	node := NewNodeServer(&Driver{})
+
+	// The driver reports statistics only for an actively mounted volume path.
+	// The root filesystem is used, as it is guaranteed to be a mount point.
+	volStatsReq := &csi.NodeGetVolumeStatsRequest{
+		VolumeId:   "remote/pvc-volume-name",
+		VolumePath: "/",
+	}
+
+	resp, err := node.NodeGetVolumeStats(t.Context(), volStatsReq)
+	require.NoError(t, err)
+	require.Len(t, resp.Usage, 2)
+
+	// Exact values depend on the filesystem the test is running on, therefore
+	// only the relation between the reported values is checked.
+	capacity := resp.Usage[0]
+	require.Equal(t, csi.VolumeUsage_BYTES, capacity.Unit)
+	require.Positive(t, capacity.Total)
+	require.LessOrEqual(t, capacity.Used+capacity.Available, capacity.Total)
+
+	inodes := resp.Usage[1]
+	require.Equal(t, csi.VolumeUsage_INODES, inodes.Unit)
+	require.Equal(t, inodes.Total, inodes.Used+inodes.Available)
+}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -257,3 +257,47 @@ func WatchFile(ctx context.Context, path string, fileChangeHandler func(path str
 
 	return nil
 }
+
+// Stats represents the capacity and inode usage of a filesystem.
+type Stats struct {
+	TotalBytes     int64
+	UsedBytes      int64
+	AvailableBytes int64
+
+	TotalInodes int64
+	UsedInodes  int64
+	FreeInodes  int64
+}
+
+// Usage returns the capacity and inode usage of the filesystem that contains the given path.
+func Usage(path string) (Stats, error) {
+	var statfs unix.Statfs_t
+
+	err := unix.Statfs(path, &statfs)
+	if err != nil {
+		return Stats{}, fmt.Errorf("Failed to get filesystem statistics for %q: %w", path, err)
+	}
+
+	// Block counts are expressed in fragment size (Frsize) units, while Bsize is only the
+	// preferred I/O size, so multiplying by Bsize would misreport capacity when the two
+	// differ. Some filesystems leave Frsize unset, in which case Bsize is the best estimate.
+	blockSize := int64(statfs.Frsize)
+	if blockSize <= 0 {
+		blockSize = int64(statfs.Bsize)
+	}
+
+	// Bfree includes blocks reserved for root, while Bavail does not. Available
+	// capacity uses Bavail, so reserved blocks count as neither used nor available.
+	// As a result, used and available bytes may not add up to the total.
+	stats := Stats{
+		TotalBytes:     int64(statfs.Blocks) * blockSize,
+		UsedBytes:      int64(statfs.Blocks-statfs.Bfree) * blockSize,
+		AvailableBytes: int64(statfs.Bavail) * blockSize,
+
+		TotalInodes: int64(statfs.Files),
+		UsedInodes:  int64(statfs.Files - statfs.Ffree),
+		FreeInodes:  int64(statfs.Ffree),
+	}
+
+	return stats, nil
+}

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -10,6 +10,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Usage of an existing path. Exact values depend on the filesystem the test is
+// running on, therefore only the relation between the reported values is checked.
+func Test_Usage(t *testing.T) {
+	dir := t.TempDir()
+
+	stats, err := Usage(dir)
+	require.NoError(t, err)
+
+	require.Positive(t, stats.TotalBytes)
+	require.GreaterOrEqual(t, stats.UsedBytes, int64(0))
+	require.GreaterOrEqual(t, stats.AvailableBytes, int64(0))
+
+	// Blocks reserved for a privileged user are not available, but are not
+	// reported as used either. Therefore, the sum of the used and available
+	// capacity does not have to match the total capacity.
+	require.LessOrEqual(t, stats.UsedBytes+stats.AvailableBytes, stats.TotalBytes)
+
+	// Used and free inodes always add up to the total number of inodes.
+	require.Equal(t, stats.TotalInodes, stats.UsedInodes+stats.FreeInodes)
+
+	// A path on the same filesystem must report the same total capacity.
+	parentStats, err := Usage(filepath.Dir(dir))
+	require.NoError(t, err)
+	require.Equal(t, stats.TotalBytes, parentStats.TotalBytes)
+}
+
+// Usage of a non-existing path must report an error.
+func Test_Usage_NotFound(t *testing.T) {
+	_, err := Usage(filepath.Join(t.TempDir(), "non-existing"))
+	require.Error(t, err)
+}
+
 // waitUntil condition returns true or timeout is reached.
 func waitUntil(t *testing.T, d time.Duration, condition func() bool) {
 	t.Helper()

--- a/test/e2e/volumestats_test.go
+++ b/test/e2e/volumestats_test.go
@@ -1,0 +1,238 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/canonical/lxd-csi-driver/test/e2e/specs"
+	"github.com/canonical/lxd-csi-driver/test/testutils"
+)
+
+// pvcRef references the PersistentVolumeClaim a volume was provisioned for.
+type pvcRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// kubeletVolumeStats is a subset of the volume statistics reported by the Kubelet Summary API.
+// Kubelet populates these from the driver's NodeGetVolumeStats procedure, therefore they reflect
+// exactly what the driver has reported.
+type kubeletVolumeStats struct {
+	CapacityBytes  int64 `json:"capacityBytes"`
+	UsedBytes      int64 `json:"usedBytes"`
+	AvailableBytes int64 `json:"availableBytes"`
+	Inodes         int64 `json:"inodes"`
+	InodesUsed     int64 `json:"inodesUsed"`
+	InodesFree     int64 `json:"inodesFree"`
+
+	PVCRef *pvcRef `json:"pvcRef,omitempty"`
+}
+
+// kubeletSummary is a subset of the Kubelet Summary API response.
+type kubeletSummary struct {
+	Pods []struct {
+		Volume []kubeletVolumeStats `json:"volume"`
+	} `json:"pods"`
+}
+
+// getVolumeStats returns the volume statistics that Kubelet on the given node reports for the given
+// PersistentVolumeClaim. Nil is returned if the statistics are not reported (yet).
+func getVolumeStats(ctx context.Context, client *kubernetes.Clientset, nodeName string, namespace string, pvcName string) (*kubeletVolumeStats, error) {
+	raw, err := client.CoreV1().RESTClient().Get().
+		Resource("nodes").
+		Name(nodeName).
+		SubResource("proxy").
+		Suffix("stats", "summary").
+		DoRaw(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve stats summary from node %q: %w", nodeName, err)
+	}
+
+	var summary kubeletSummary
+	err = json.Unmarshal(raw, &summary)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse stats summary from node %q: %w", nodeName, err)
+	}
+
+	for _, pod := range summary.Pods {
+		for _, volume := range pod.Volume {
+			if volume.PVCRef != nil && volume.PVCRef.Name == pvcName && volume.PVCRef.Namespace == namespace {
+				return &volume, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// waitVolumeStats waits until Kubelet reports the volume statistics for the given PersistentVolumeClaim.
+// Kubelet collects the statistics periodically (once per minute by default), therefore they are not
+// available immediately after the pod becomes ready.
+func waitVolumeStats(ctx context.Context, client *kubernetes.Clientset, nodeName string, namespace string, pvcName string) *kubeletVolumeStats {
+	var stats *kubeletVolumeStats
+
+	ginkgo.By("Wait for Kubelet to report volume stats for PVC " + namespace + "/" + pvcName)
+	gomega.Eventually(func() (*kubeletVolumeStats, error) {
+		var err error
+		stats, err = getVolumeStats(ctx, client, nodeName, namespace, pvcName)
+		return stats, err
+	}).WithTimeout(3*time.Minute).WithPolling(10*time.Second).ShouldNot(gomega.BeNil(),
+		"Kubelet did not report volume stats for PVC %q on node %q", pvcName, nodeName)
+
+	return stats
+}
+
+var _ = ginkgo.DescribeTableSubtree("[Volume stats]", func(driver string) {
+	var cfg *rest.Config
+	var namespace = "default"
+
+	ginkgo.BeforeEach(func() {
+		cfg = testutils.GetClientConfig()
+	})
+
+	ginkgo.It("Report stats for FS volume",
+		func(ctx ginkgo.SpecContext) {
+			poolName, cleanup := getTestLXDStoragePool(driver)
+			defer cleanup()
+
+			client := testutils.GetKubernetesClient(cfg)
+
+			sc := specs.NewStorageClass(cfg, "sc", poolName)
+			sc.Create(ctx)
+			defer sc.ForceDelete(context.Background())
+
+			pvc := specs.NewPersistentVolumeClaim(cfg, "pvc", namespace).
+				WithStorageClassName(sc.Name)
+			pvc.Create(ctx)
+			defer pvc.ForceDelete(context.Background())
+
+			pod := specs.NewPod(cfg, "pod", namespace).WithPVC(pvc, "/mnt/test")
+			pod.Create(ctx)
+			defer pod.ForceDelete(context.Background())
+			pod.WaitReady(ctx)
+
+			state, err := pod.State(ctx)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(state.Spec.NodeName).NotTo(gomega.BeEmpty())
+
+			nodeName := state.Spec.NodeName
+			stats := waitVolumeStats(ctx, client, nodeName, namespace, pvc.Name)
+
+			// Filesystem volumes report the capacity.
+			gomega.Expect(stats.CapacityBytes).To(gomega.BeNumerically(">", 0))
+
+			// The inode usage is reported only by filesystems that preallocate the
+			// inodes. Btrfs allocates them dynamically, therefore it reports no
+			// inode counts at all.
+			if driver == "btrfs" {
+				gomega.Expect(stats.Inodes).To(gomega.BeZero())
+			} else {
+				gomega.Expect(stats.Inodes).To(gomega.BeNumerically(">", 0))
+				gomega.Expect(stats.InodesUsed + stats.InodesFree).To(gomega.Equal(stats.Inodes))
+			}
+
+			// Blocks reserved for a privileged user are not available, but are not
+			// reported as used either. Therefore, the sum of the used and available
+			// capacity does not have to match the total capacity.
+			gomega.Expect(stats.UsedBytes + stats.AvailableBytes).To(gomega.BeNumerically("<=", stats.CapacityBytes))
+
+			if driver == "dir" {
+				// The "dir" storage driver cannot bound the volume size, as the volume
+				// is a plain directory on the host filesystem. Therefore the reported
+				// capacity belongs to the filesystem that backs the storage pool and
+				// no assumptions can be made about the reported values.
+				return
+			}
+
+			// Reported capacity must not exceed the requested volume size.
+			// Btrfs is an exception, as it bounds the volume with a qgroup limit, which
+			// is not reflected in the filesystem statistics. Its volumes therefore
+			// report the capacity of the entire storage pool.
+			if driver != "btrfs" {
+				gomega.Expect(stats.CapacityBytes).To(gomega.BeNumerically("<=", 64*1024*1024))
+			}
+
+			// Write a known amount of data and ensure the reported usage grows.
+			// Random data is used because storage drivers may support compression,
+			// in which case an easily compressible content would occupy no space.
+			usedBytes := stats.UsedBytes
+			_, err = pod.Exec(ctx, []string{"sh", "-c", "dd if=/dev/urandom of=/mnt/test/data bs=1M count=8 conv=fsync status=none"})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Wait for Kubelet to report increased volume usage")
+			gomega.Eventually(func() (int64, error) {
+				stats, err := getVolumeStats(ctx, client, nodeName, namespace, pvc.Name)
+				if err != nil {
+					return 0, err
+				}
+
+				if stats == nil {
+					return 0, fmt.Errorf("Kubelet does not report volume stats for PVC %q", pvc.Name)
+				}
+
+				return stats.UsedBytes, nil
+			}).WithTimeout(3*time.Minute).WithPolling(10*time.Second).Should(gomega.BeNumerically(">=", usedBytes+4*1024*1024),
+				"Kubelet did not report increased volume usage after writing 8MiB")
+
+			// Cleanup.
+			pod.Delete(ctx)
+			pvc.Delete(ctx)
+		},
+		ginkgo.SpecTimeout(10*time.Minute),
+	)
+
+	ginkgo.It("Report stats for block volume",
+		func(ctx ginkgo.SpecContext) {
+			if driver == "dir" {
+				ginkgo.Skip("Skipping block volume stats test for 'dir' driver, as it does not support volume size")
+			}
+
+			poolName, cleanup := getTestLXDStoragePool(driver)
+			defer cleanup()
+
+			client := testutils.GetKubernetesClient(cfg)
+
+			sc := specs.NewStorageClass(cfg, "sc", poolName)
+			sc.Create(ctx)
+			defer sc.ForceDelete(context.Background())
+
+			pvc := specs.NewPersistentVolumeClaim(cfg, "pvc", namespace).
+				WithStorageClassName(sc.Name).
+				WithVolumeMode(corev1.PersistentVolumeBlock)
+			pvc.Create(ctx)
+			defer pvc.ForceDelete(context.Background())
+
+			pod := specs.NewPod(cfg, "pod", namespace).WithPVC(pvc, "/dev/vda42")
+			pod.Create(ctx)
+			defer pod.ForceDelete(context.Background())
+			pod.WaitReady(ctx)
+
+			state, err := pod.State(ctx)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(state.Spec.NodeName).NotTo(gomega.BeEmpty())
+
+			stats := waitVolumeStats(ctx, client, state.Spec.NodeName, namespace, pvc.Name)
+
+			// Raw block volumes are not formatted by the driver, therefore only the
+			// total size of the block device is reported.
+			gomega.Expect(stats.CapacityBytes).To(gomega.BeNumerically(">", 0))
+			gomega.Expect(stats.CapacityBytes).To(gomega.BeNumerically("<=", 64*1024*1024))
+			gomega.Expect(stats.UsedBytes).To(gomega.BeZero())
+			gomega.Expect(stats.AvailableBytes).To(gomega.BeZero())
+			gomega.Expect(stats.Inodes).To(gomega.BeZero())
+
+			// Cleanup.
+			pod.Delete(ctx)
+			pvc.Delete(ctx)
+		},
+		ginkgo.SpecTimeout(10*time.Minute),
+	)
+}, getTestLXDStorageDrivers())


### PR DESCRIPTION
This PR implements node service capability `GET_VOLUME_STATS`, which lets kubelet scrap volume stats. This allows kubelet to report PVC stats, which is especially useful for metrics.